### PR TITLE
fix(HOTFIX Scroll Bug): Update condition in observer

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,6 @@
 	import SocialLinks from '$lib/components/SocialLinks.svelte'
 
 	let title = 'Corey Damocles | Projects'
-
 	let aboutInView = false
 	let experienceInView = false
 
@@ -25,7 +24,7 @@
 					if (target.id === 'about') {
 						aboutInView = isIntersecting
 						experienceInView = !isIntersecting
-					} else if (target.id === 'experience') {
+					} else if (target.id === 'experience' && window.scrollY > aboutElement.clientHeight) {
 						experienceInView = isIntersecting
 						aboutInView = !isIntersecting
 					}


### PR DESCRIPTION
Fixed bug where `experienceInView` was set to true instead of `aboutInView` when first visiting the homepage without having scrolled.


![Screenshot 2024-02-16 at 10 47 27 AM](https://github.com/ubemacapuno/corey-damocles-portfolio-v2/assets/97559559/d697893f-3608-4ec1-85c3-f5a735dca7db)
